### PR TITLE
Use package-private for Jupiter tests

### DIFF
--- a/oss-quickstart-simple-archetype/src/main/resources/archetype-resources/src/test/java/AppTest.java
+++ b/oss-quickstart-simple-archetype/src/main/resources/archetype-resources/src/test/java/AppTest.java
@@ -22,10 +22,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.*;
 
-public class AppTest {
+class AppTest {
 
     @Test
-    public void helloShouldReturnName() {
+    void helloShouldReturnName() {
         App app = new App();
         assertThat(app.hello("Bob")).isEqualTo("Hello, Bob");
     }


### PR DESCRIPTION
Jupiter fosters the use of package-private modifiers for test classes and methods (SonarQube also fosters that).